### PR TITLE
Fixed Update Site Name

### DIFF
--- a/ch.ethz.eventb.utils-feature/feature.properties
+++ b/ch.ethz.eventb.utils-feature/feature.properties
@@ -32,18 +32,25 @@ Event-B elements.\n\
 \n\
 Release history\n\
 ---------------\n\
+### Version 0.2.6 - Fixed Update Site Name ###\n\
+- The Update Site Name is "Soton Plug-ins" to be consistent with the Rodin \
+platform.\n\
 ### Version 0.2.5 - Use EPL 2.0 ###\n\
+#### Updated Plug-ins ####\n\
 - Event-B Utils (0.2.5): Use EPL 2.0 instead of EPL 1.0\n\
 ### Version 0.2.4 - Implement method to get invariants ###\n\
-- add method getSCInvariants() to EventBSCUtils to get the invariants\
+#### Updated Plug-ins ####\n\
+- Event-B Utils (0.2.4): add method getSCInvariants() to EventBSCUtils to get the invariants\
  from statically checked machine.\n\
 \n\
 ### Version 0.2.3 - Implement method to get variables' type ###\n\
-- add method getVariableType(...) to EventBSCUtils to get the type of a\
+#### Updated Plug-ins ####\n\
+- Event-B Utils (0.2.3): add method getVariableType(...) to EventBSCUtils to get the type of a\
  variable from the statically checked machine\n\
 \n\
 ### Version 0.2.2 - Utilities related to Event-B UI ###\n\
-- Added utilities related to Event-B UI: Event-B content provider,\
+#### Updated Plug-ins ####\n\
+- Event-B Utils (0.2.2): Added utilities related to Event-B UI: Event-B content provider,\
  Event-B label provider, Event-B viewer filter.\n\
 \n\
 ### Version 0.2.1 - Publish the SDK feature ###\n\
@@ -54,4 +61,4 @@ Release history\n\
 featureCopyright=Copyright (c) 2010, 2021 ETH Zurich and others. All rights reserved.
 
 # "updateSiteName" property - name of the update site
-updateSiteName=UML-B and CamilleX Update Site
+updateSiteName=Soton Plug-ins

--- a/ch.ethz.eventb.utils-feature/feature.xml
+++ b/ch.ethz.eventb.utils-feature/feature.xml
@@ -15,7 +15,7 @@
 <feature
       id="ch.ethz.eventb.utils_feature"
       label="%featureName"
-      version="0.2.5.release"
+      version="0.2.6.release"
       provider-name="%featureVendor"
       license-feature="org.rodinp.licence"
       license-feature-version="1.0.0.release">

--- a/ch.ethz.eventb.utils.sdk/feature.properties
+++ b/ch.ethz.eventb.utils.sdk/feature.properties
@@ -32,26 +32,37 @@ Event-B elements including source code and tests.\n\
 \n\
 Release history\n\
 ---------------\n\
+### Version 0.2.6 - Fixed Update Site Name ###\n\
+- The Update Site Name is "Soton Plug-ins" to be consistent with the Rodin \
+platform.\n\
+#### Updated Plug-ins/Features ####\n\
+- Event-B Utilities Feature (0.2.6)\n\
+- Event-B Utilities Test Feature (0.2.6)\n\
 ### Version 0.2.5 - Use EPL 2.0 ###\n\
+#### Updated Plug-ins/Features ####\n\
 - Event-B Utilities Feature (0.2.5)\n\
 - Event-B Utilities Source Feature (0.2.5): Generated\n\
-- Event-B Utilities Test Feature (0.2.5): Initial version\n\
+- Event-B Utilities Test Feature (0.2.5)\n\
 - Event-B Utilities Test Source Feature (0.2.5): Generated\n\
 ### Version 0.2.4 - Implement method to get invariants ###\n\
+#### Updated Plug-ins/Features ####\n\
 - Event-B Utilities Feature (0.2.4)\n\
 - Event-B Utilities Source Feature (0.2.4): Generated\n\
 - Event-B Utilities Test Feature (0.2.4): Initial version\n\
 - Event-B Utilities Test Source Feature (0.2.4): Generated\n\
 \n\
 ### Version 0.2.3 - Implement method to get variables' type ###\n\
+#### Updated Plug-ins/Features ####\n\
 - Event-B Utilities Feature 0.2.3\n\
 - Event-B Utilities Source plug-in 0.2.3: Generated\n\
 \n\
 ### Version 0.2.2 - Utilities related to Event-B UI ###\n\
+#### Updated Plug-ins/Features ####\n\
 - Event-B Utilities Feature 0.2.2\n\
 - Event-B Utilities Source plug-in 0.2.2: Generated\n\
 \n\
 ### Version 0.2.1 - Initial version ###\n\
+#### Updated Plug-ins/Features ####\n\
 - Event-B Utilities Feature 0.2.1\n\
 - Event-B Utilities Source plug-in 0.2.1: Generated\n\
 - Event-B Utilities Test plug-in 0.2.1\n\
@@ -61,4 +72,4 @@ Release history\n\
 featureCopyright=Copyright (c) 2015, 2021 University of Southampton. All rights reserved.
 
 # "updateSiteName" property - name of the update site
-updateSiteName=UML-B and CamilleX Update Site
+updateSiteName=Soton Plug-ins

--- a/ch.ethz.eventb.utils.sdk/feature.xml
+++ b/ch.ethz.eventb.utils.sdk/feature.xml
@@ -15,7 +15,7 @@
 <feature
       id="ch.ethz.eventb.utils.sdk"
       label="%featureName"
-      version="0.2.5.release"
+      version="0.2.6.release"
       provider-name="%featureVendor"
       license-feature="org.rodinp.licence"
       license-feature-version="1.0.0.release">

--- a/ch.ethz.eventb.utils.tests.feature/feature.properties
+++ b/ch.ethz.eventb.utils.tests.feature/feature.properties
@@ -27,13 +27,17 @@ This feature provides tests for the Event-B Utilities feature.\n\
 \n\
 Release history\n\
 ---------------\n\
+### 0.2.6 Fixed Update Site Name ###\n\
+- Change the Update Site to "Soton Plug-ins".\n\
 ### Version 0.2.5 - Use EPL 2.0 ###\n\
+#### Updated Plug-ins ####\n\
 - Event-B Utilities Tests (0.2.5): Use EPL 2.0 instead of EPL 1.0\n\
 ### Version 0.2.4 - Initial version ###\n\
+#### Updated Plug-ins ####\n\
 - Event-B Utilities Tests (0.2.4)
 
 # "copyright" property - copyright of the feature
 featureCopyright=Copyright (c) 2017, 2021 University of Southampton. All rights reserved.
 
 # "updateSiteName" property - name of the update site
-updateSiteName=UML-B and CamilleX Update Site
+updateSiteName=Soton Plug-ins

--- a/ch.ethz.eventb.utils.tests.feature/feature.xml
+++ b/ch.ethz.eventb.utils.tests.feature/feature.xml
@@ -15,7 +15,7 @@
 <feature
       id="ch.ethz.eventb.utils.tests.feature"
       label="%featureName"
-      version="0.2.5.release"
+      version="0.2.6.release"
       provider-name="%featureVendor"
       license-feature="org.rodinp.licence"
       license-feature-version="1.0.0.release">


### PR DESCRIPTION
The Update Site name is "Soton Plug-ins" to be consistent with the Rodin Platform.